### PR TITLE
Add --no-source-maps to 'build' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "start": "parcel src/index.html",
-    "build": "parcel build src/index.html",
+    "build": "parcel build src/index.html --no-source-maps",
     "clean": "rimraf \"{dist/*.{png,html,js,map,css},.cache}\"",
     "format": "prettier --write \"./src/**/*.{html,css,ts,tsx}\"",
     "test": "jest"


### PR DESCRIPTION
Source maps are unnecessary for production build and potentially dangerous.