### PR TITLE
chore: Fix typeRoots

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    "typeRoots": ["./types"],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["./types", "./node_modules/@types"],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
Resolves #207 

https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types
>If typeRoots is specified, only packages under typeRoots will be included. For example:
>```
>{
>   "compilerOptions": {
>       "typeRoots" : ["./typings"]
>   }
>}
>```
>This config file will include all packages under ./typings, and no packages from ./node_modules/@types.
