### PR TITLE
Fix modal overlay z-index bug

### DIFF
--- a/src/index.pcss
+++ b/src/index.pcss
@@ -90,3 +90,8 @@ select {
   appearance: none;
   width: 100%;
 }
+
+#overlay {
+  position: relative;
+  z-index: 1000;
+}


### PR DESCRIPTION
## as is

<img width="980" alt="スクリーンショット 2020-01-03 14 29 53" src="https://user-images.githubusercontent.com/6993514/71708593-c9ae2900-2e35-11ea-8f8d-107c6c435eba.png">

## to be

<img width="978" alt="スクリーンショット 2020-01-03 14 32 05" src="https://user-images.githubusercontent.com/6993514/71708602-daf73580-2e35-11ea-9a35-179a949500cc.png">
