### PR TITLE
Stop to fetch ogp when ogcard won't be shown

### DIFF
--- a/src/furui/containers/og-card.tsx
+++ b/src/furui/containers/og-card.tsx
@@ -10,8 +10,9 @@ export default ({
   url: string
   className: string
 }) => {
+  if (!appStore.getPreference(PREFERENCE_DISPLAY_OGCARD)) return <></>
   const r = useWebpageMeta(url)
-  if (!r || !appStore.getPreference(PREFERENCE_DISPLAY_OGCARD)) return <></>
+  if (!r) return <></>
   return OGCard(
     Object.assign(
       {


### PR DESCRIPTION
無駄な通信が発生するので

React hooks のルールにはひっかかっていなさそうな雰囲気
