### PR TITLE
Nキーでフォーカスできないのを直した

### DIFF
--- a/src/furui/presenters/local-timeline-content/post-form/index.tsx
+++ b/src/furui/presenters/local-timeline-content/post-form/index.tsx
@@ -52,7 +52,7 @@ export default forwardRef<HTMLTextAreaElement, T>(
             onKeyDown={onKeyDown}
             onChange={onChange}
             onPaste={onPaste}
-            inputRef={ref!}
+            ref={ref!}
             placeholder="What's up Otaku?"
             value={draft}
           ></Textarea>


### PR DESCRIPTION
react-textarea-autosizeの8.0.0でbreaking changeがあったのでそれに対応しただけ