### PR TITLE
inReplyTo: react-overlay の rootClose を使わない形にしてみる

### DIFF
--- a/src/components/hooks/index.ts
+++ b/src/components/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-relative-time-represent'
+export * from './use-outside-click'

--- a/src/components/hooks/use-outside-click.ts
+++ b/src/components/hooks/use-outside-click.ts
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+export const useOutsideClick = (
+  ref: React.RefObject<HTMLElement>,
+  handler: () => void
+) => {
+  React.useEffect(() => {
+    if (ref.current == null) return
+    const outsideClickHandler = (e: any) => {
+      if (e.currentTarget === null) return
+      if (ref.current!.contains(e.target)) return
+      handler()
+    }
+    window.addEventListener('click', outsideClickHandler)
+    return () => {
+      window.removeEventListener('click', outsideClickHandler)
+    }
+  }, [ref, handler])
+}


### PR DESCRIPTION
+ rootClose 使わないと簡単なのでは説
  * 単に rootClose って名前が最悪ってだけではある